### PR TITLE
bugfix: do not omit Date objects.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,10 +10,13 @@
 var reduce = require('reduce-object');
 var hasValues = require('has-values');
 var isObject = require('isobject');
+var isDateObject = require('is-date-object');
 
 module.exports = function omitEmpty(o, noZero) {
   return reduce(o, function (acc, value, key) {
-    if (isObject(value)) {
+    if (isDateObject(value)) {
+      acc[key] = value;
+    } else if (isObject(value)) {
       var val = omitEmpty(value, noZero);
       if (hasValues(val)) {
         acc[key] = val;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "has-values": "^0.1.3",
+    "is-date-object": "^1.0.1",
     "isobject": "^2.0.0",
     "reduce-object": "^0.1.3"
   },

--- a/test.js
+++ b/test.js
@@ -44,6 +44,11 @@ describe('.omitEmpty()', function () {
     omitEmpty({a: {b: {c: 'foo', d: 0}, foo: [], bar: false}}).should.eql({a: {b: {c: 'foo', d: 0}, bar: false}});
   });
 
+  it('should not omit Dates.', function () {
+    var today = new Date()
+    omitEmpty({a: {b: {c: 'foo', d: today}, foo: [], bar: false}}).should.eql({a: {b: {c: 'foo', d: today}, bar: false}});
+  });
+
   it('should handle complex objects.', function () {
     var o = {a: {b: {c: 'foo', d: 0, e: {f: {g: {}, h: {i: 'i'}}}}, foo: [['bar', 'baz'], []], bar: [], one: 1, two: 2, three: 0 } };
     omitEmpty(o).should.eql({a: {b: {c: 'foo', d: 0, e: {f: {h: {i: 'i'}}}}, foo: [['bar', 'baz'], []], one: 1, two: 2, three: 0}});


### PR DESCRIPTION
Fixes (https://github.com/jonschlinkert/omit-empty/issues/1), by using `is-date-object` before `is-object`. This is because `is-object` (correctly) considers `new Date()` as an object, but we don't want recursion in this case.
