### PR TITLE
Extend options to allow empty arrays and ignored properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,24 @@ console.log(omitEmpty({ a: ['a'], b: [] }));
 console.log(omitEmpty({ a: 0, b: 1 }));
 //=> { a: 0, b: 1 }
 
+## Options
+When calling `omitEmpty`, you can pass options to control behavior:
+
+| Option key | default | description |
+|---|---|---|
+|omitZero|false| When set to `true` causes any properties with a value of 0 to be removed|
+|omitEmptyArray|true| When set to `false` empty arrays will be preserved|
+|excludeProperties| | Specify a list of string properties that will be ignored. Currently this does NOT support dot-notation paths. Any property name will match at all levels.|
+
+Examples:
+
+```js
 // set omitZero to true, to evaluate "0" as falsey
 console.log(omitEmpty({ a: 0, b: 1 }, { omitZero: true }));
 //=> { b: 1 }
 ```
+
+
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ When calling `omitEmpty`, you can pass options to control behavior:
 |---|---|---|
 |omitZero|false| When set to `true` causes any properties with a value of 0 to be removed|
 |omitEmptyArray|true| When set to `false` empty arrays will be preserved|
-|excludeProperties| | Specify a list of string properties that will be ignored. Currently this does NOT support dot-notation paths. Any property name will match at all levels.|
+|excludeProperties| | Specify a list of string properties that will be skipped. If the property is an object, then the value will not be recursed (meaning, omit-empty is not run on the nested object.|
 
 Examples:
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,9 @@ const omitEmpty = (obj, options = {}) => {
     if (typeOf(value) === 'object') {
       let result = {};
       for (let key of Object.keys(value)) {
-        if (!opts.excludedProperties.includes(key)) {
+        if (opts.excludeProperties.includes(key)) {
+          result[key] = value[key];
+        } else {
           let val = omit(value[key], opts);
           if (val !== void 0) {
             result[key] = val;
@@ -38,8 +40,8 @@ const omitEmpty = (obj, options = {}) => {
 function _buildRuntimeOpts(options = {}) {
   return {
     omitZero: options.omitZero || false,
-    omitEmptyArray: options.omitEmptyArray || true,
-    excludedProperties: options.excludedProperties || []
+    omitEmptyArray: options.omitEmptyArray === false ? false : true,
+    excludeProperties: options.excludeProperties || []
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omit-empty",
   "description": "Recursively omit empty properties from an object. Omits empty objects, arrays, strings or zero.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "homepage": "https://github.com/jonschlinkert/omit-empty",
   "author": "Jon Schlinkert (https://github.com/jonschlinkert)",
   "repository": "jonschlinkert/omit-empty",

--- a/test.js
+++ b/test.js
@@ -25,6 +25,11 @@ describe('omit-empty', () => {
     assert.deepEqual(omitEmpty(['foo']), ['foo']);
   });
 
+  it('should return empty arrays with option config', () => {
+    assert.deepEqual(omitEmpty(['foo'], { omitEmptyArray: false }), ['foo']);
+  });
+
+
   it('should return undefined when the value is an empty string', () => {
     assert.equal(omitEmpty(''), void 0);
   });
@@ -60,9 +65,9 @@ describe('omit-empty', () => {
   });
 
   it('should omit nested empty objects.', () => {
-    assert.deepEqual(omitEmpty({ a: { b: undefined, c: 'd' } }), { a: { c: 'd' }});
-    assert.deepEqual(omitEmpty({ a: { b: null, c: 'd' } }), { a: { c: 'd' }});
-    assert.deepEqual(omitEmpty({ a: { b: '', c: 'd' } }), { a: { c: 'd' }});
+    assert.deepEqual(omitEmpty({ a: { b: undefined, c: 'd' } }), { a: { c: 'd' } });
+    assert.deepEqual(omitEmpty({ a: { b: null, c: 'd' } }), { a: { c: 'd' } });
+    assert.deepEqual(omitEmpty({ a: { b: '', c: 'd' } }), { a: { c: 'd' } });
   });
 
   it('should deeply omit nested empty objects.', () => {
@@ -72,8 +77,8 @@ describe('omit-empty', () => {
   });
 
   it('should not omit functions', () => {
-    let fn = (a, b, c) => {};
-    let fn2 = () => {};
+    let fn = (a, b, c) => { };
+    let fn2 = () => { };
     assert.deepEqual(omitEmpty({ a: fn, b: fn2 }), { a: fn, b: fn2 });
   });
 

--- a/test.js
+++ b/test.js
@@ -152,4 +152,28 @@ describe('omit-empty', () => {
       }
     });
   });
+
+  it('should omit deeply nested values with Config options', () => {
+    let o = {
+      a: {
+        b: { c: 'foo', d: 0, e: { f: { g: {}, h: { i: 'i' } } } },
+        foo: [['bar', 'baz'], []],
+        bar: [],
+        one: 1,
+        two: 2,
+        three: 0
+      }
+    };
+
+    assert.deepEqual(omitEmpty(o, { omitEmptyArray: false, omitZero: true, excludeProperties: ['three'] }), {
+      a: {
+        b: { c: 'foo', e: { f: { h: { i: 'i' } } } },
+        foo: [['bar', 'baz'], []],
+        bar: [],
+        one: 1,
+        two: 2,
+        three: 0
+      }
+    });
+  });
 });


### PR DESCRIPTION
When building responses for REST List responses, an empty array is significant. So extended options to allow them to pass through.

Also added support for a  simple-minded excludedProperties to prevent omitEmpty from traversing/processing specific properties. (Just in case you want to exclude something from processing due to weirdness in requirements.